### PR TITLE
Workaround for meta-command handling in sqlc

### DIFF
--- a/sql/sql.go
+++ b/sql/sql.go
@@ -137,8 +137,8 @@ func DumpSchema() error {
 	ok, err := sh.Exec(nil, outFile, os.Stderr,
 		"docker", "run", "--rm", "--network", "host",
 		postgresImage,
-		"pg_dump", connString,
-		"--schema-only", "--no-owner", "--no-privileges",
+		"sh", "-c",
+		fmt.Sprintf("pg_dump %s --schema-only --no-owner --no-privileges | sed -e 's/^\\\\\\(un\\)\\?restrict.*//'", connString),
 	)
 	if err != nil {
 		return fmt.Errorf("run pg_dump: %w", err)

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -1,6 +1,8 @@
 package sql
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -134,11 +136,14 @@ func DumpSchema() error {
 		return fmt.Errorf("create schema file: %w", err)
 	}
 
-	ok, err := sh.Exec(nil, outFile, os.Stderr,
+	// Buffer for keeping the dumped schema in memory for postprocessing.
+	var buf bytes.Buffer
+
+	ok, err := sh.Exec(nil, &buf, os.Stderr,
 		"docker", "run", "--rm", "--network", "host",
 		postgresImage,
-		"sh", "-c",
-		fmt.Sprintf("pg_dump %s --schema-only --no-owner --no-privileges | sed -e 's/^\\\\\\(un\\)\\?restrict.*//'", connString),
+		"pg_dump", connString,
+		"--schema-only", "--no-owner", "--no-privileges",
 	)
 	if err != nil {
 		return fmt.Errorf("run pg_dump: %w", err)
@@ -148,7 +153,56 @@ func DumpSchema() error {
 		return errors.New("failed to run pg_dump in docker")
 	}
 
+	// Scanner that will read the dumped schema line by line.
+	scan := bufio.NewScanner(&buf)
+
+	var (
+		restrict   = []byte("\\restrict")
+		unrestrict = []byte("\\unrestrict")
+		nl         = []byte("\n")
+	)
+
+	var writeErr error
+
+	for scan.Scan() {
+		line := scan.Bytes()
+
+		// Ignore the \restrict and \unrestrict directives.
+		if hasAnyPrefix(line, restrict, unrestrict) {
+			continue
+		}
+
+		_, writeErr = outFile.Write(line)
+		if writeErr != nil {
+			break
+		}
+
+		_, writeErr = outFile.Write(nl)
+		if writeErr != nil {
+			break
+		}
+	}
+
+	if writeErr != nil {
+		return fmt.Errorf("write to schema.sql: %w", writeErr)
+	}
+
+	readErr := scan.Err()
+	if readErr != nil {
+		return fmt.Errorf("read from database dump: %w", readErr)
+	}
+
 	return nil
+}
+
+func hasAnyPrefix(line []byte, prefixes ...[]byte) bool {
+	for _, p := range prefixes {
+		if bytes.HasPrefix(line, p) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Postgres creates a local Postgres instance using docker.


### PR DESCRIPTION
This incredibly ugly patch is a workaround for
https://github.com/sqlc-dev/sqlc/issues/4065 until the parsing behaviour has
been fixed in sqlc
